### PR TITLE
VAE Deterministic Forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed VAE to use mean of encoder distributions in forward function, instead of random sampling. This follows best practice for inference ([#761](https://github.com/PyTorchLightning/lightning-bolts/pull/761))
 
 ### Deprecated
 

--- a/pl_bolts/models/autoencoders/basic_vae/basic_vae_module.py
+++ b/pl_bolts/models/autoencoders/basic_vae/basic_vae_module.py
@@ -105,13 +105,13 @@ class VAE(LightningModule):
         return self.load_from_checkpoint(VAE.pretrained_urls[checkpoint_name], strict=False)
 
     def forward(self, x):
+        # deterministic forward
         x = self.encoder(x)
         mu = self.fc_mu(x)
-        log_var = self.fc_var(x)
-        p, q, z = self.sample(mu, log_var)
-        return self.decoder(z)
+        return self.decoder(mu)
 
     def _run_step(self, x):
+        # stochastic forward
         x = self.encoder(x)
         mu = self.fc_mu(x)
         log_var = self.fc_var(x)


### PR DESCRIPTION
## What does this PR do?

Changes the forward function to use the mean of the encoder distributions rather than sampling from them. (This function is intended to be used during inference, not training)

Fixes #566

**Rationale**
- This is more in line with best practice, one of the goals of lightning-bolts
- For inference it is not ideal if the forward function is non-deterministic. You want to decode the mean of the posterior distribution rather than sampling from them if you are making predictions. It doesn't help if your predictions are always changing.
- Sampling is usually only useful during training because of the regularisation effect it introduces. It might be worth exposing _run_step and changing its name to (or creating a variant of it called) forward_stocastic so that it is clear that there is a difference.

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does **only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes?
- [ ] Did you write any **new necessary tests**? \[not needed for typos/docs\]
- [ ] Did you verify new and **existing tests** pass locally with your changes? (I struggled to get them running)
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

## PR review

- [ ] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
