### PR TITLE
Introduce catch_warnings fixture

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ norecursedirs =
     dist
     build
 addopts =
-    --strict
+    --strict-markers
     --doctest-modules
     --durations=0
     --color=yes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
+import warnings
 from pathlib import Path
 
 import pytest
+
+from pl_bolts.utils.stability import UnderReviewWarning
 
 # GitHub Actions use this path to cache datasets.
 # Use `datadir` fixture where possible and use `DATASETS_PATH` in
@@ -12,3 +15,11 @@ from tests import DATASETS_PATH
 @pytest.fixture(scope="session")
 def datadir():
     return Path(DATASETS_PATH)
+
+
+@pytest.fixture
+def catch_warnings():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        warnings.simplefilter("ignore", UnderReviewWarning)
+        yield


### PR DESCRIPTION
## What does this PR do?

Introduces `catch_warnings` pytest fixture, which reviewers can use to check, that no warnings other than `UnderReviewWarning` is emitted during the test

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does **only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes?
- [x] Did you write any **new necessary tests**? \[not needed for typos/docs\]
- [x] Did you verify new and **existing tests** pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review

- [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
