### PR TITLE
limit mistune version to unblock doctest

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx==4.2  # fails with sphinx.ext.viewcode  # fails with sphinx_paramlinks
 recommonmark  # fails with badges
+mistune < 2.0
 m2r  # fails with multi-line text
 nbsphinx>=0.8
 pandoc>=1.0


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Due to this [issue](https://github.com/lepture/mistune/issues/291), `sphinx-build` is broken currently. The workaround is to limit to older version of `mistune`

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does **only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes?
- [x] Did you write any **new necessary tests**? \[not needed for typos/docs\]
- [x] Did you verify new and **existing tests** pass locally with your changes?
- [n/a] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review

- [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
