### PR TITLE
Dataset specific args method to CIFAR10, ImageNet, MNIST, and STL10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.8
+  python: python3.9
 
 ci:
   autofix_prs: true

--- a/pl_bolts/datamodules/cifar10_datamodule.py
+++ b/pl_bolts/datamodules/cifar10_datamodule.py
@@ -124,7 +124,7 @@ class CIFAR10DataModule(VisionDataModule):
         return cf10_transforms
 
     @staticmethod
-    def add_dataset_specific_args(parent_parser) -> ArgumentParser:
+    def add_dataset_specific_args(parent_parser: ArgumentParser) -> ArgumentParser:
         parser = ArgumentParser(parents=[parent_parser], add_help=False)
 
         parser.add_argument("--data_dir", type=str, default=".")

--- a/pl_bolts/datamodules/cifar10_datamodule.py
+++ b/pl_bolts/datamodules/cifar10_datamodule.py
@@ -1,3 +1,4 @@
+from argparse import ArgumentParser
 from typing import Any, Callable, Optional, Sequence, Union
 
 from pl_bolts.datamodules.vision_datamodule import VisionDataModule
@@ -121,6 +122,16 @@ class CIFAR10DataModule(VisionDataModule):
             cf10_transforms = transform_lib.Compose([transform_lib.ToTensor()])
 
         return cf10_transforms
+
+    @staticmethod
+    def add_dataset_specific_args(parent_parser) -> ArgumentParser:
+        parser = ArgumentParser(parents=[parent_parser], add_help=False)
+
+        parser.add_argument("--data_dir", type=str, default=".")
+        parser.add_argument("--num_workers", type=int, default=0)
+        parser.add_argument("--batch_size", type=int, default=32)
+
+        return parser
 
 
 @under_review()

--- a/pl_bolts/datamodules/imagenet_datamodule.py
+++ b/pl_bolts/datamodules/imagenet_datamodule.py
@@ -1,4 +1,5 @@
 import os
+from argparse import ArgumentParser
 from typing import Any, Callable, Optional
 
 from pytorch_lightning import LightningDataModule
@@ -259,3 +260,13 @@ class ImagenetDataModule(LightningDataModule):
             ]
         )
         return preprocessing
+
+    @staticmethod
+    def add_dataset_specific_args(parent_parser) -> ArgumentParser:
+        parser = ArgumentParser(parents=[parent_parser], add_help=False)
+
+        parser.add_argument("--data_dir", type=str, default=".")
+        parser.add_argument("--num_workers", type=int, default=0)
+        parser.add_argument("--batch_size", type=int, default=32)
+
+        return parser

--- a/pl_bolts/datamodules/imagenet_datamodule.py
+++ b/pl_bolts/datamodules/imagenet_datamodule.py
@@ -262,7 +262,7 @@ class ImagenetDataModule(LightningDataModule):
         return preprocessing
 
     @staticmethod
-    def add_dataset_specific_args(parent_parser) -> ArgumentParser:
+    def add_dataset_specific_args(parent_parser: ArgumentParser) -> ArgumentParser:
         parser = ArgumentParser(parents=[parent_parser], add_help=False)
 
         parser.add_argument("--data_dir", type=str, default=".")

--- a/pl_bolts/datamodules/mnist_datamodule.py
+++ b/pl_bolts/datamodules/mnist_datamodule.py
@@ -1,3 +1,4 @@
+from argparse import ArgumentParser
 from typing import Any, Callable, Optional, Union
 
 from pl_bolts.datamodules.vision_datamodule import VisionDataModule
@@ -106,3 +107,13 @@ class MNISTDataModule(VisionDataModule):
             mnist_transforms = transform_lib.Compose([transform_lib.ToTensor()])
 
         return mnist_transforms
+
+    @staticmethod
+    def add_dataset_specific_args(parent_parser) -> ArgumentParser:
+        parser = ArgumentParser(parents=[parent_parser], add_help=False)
+
+        parser.add_argument("--data_dir", type=str, default=".")
+        parser.add_argument("--num_workers", type=int, default=0)
+        parser.add_argument("--batch_size", type=int, default=32)
+
+        return parser

--- a/pl_bolts/datamodules/mnist_datamodule.py
+++ b/pl_bolts/datamodules/mnist_datamodule.py
@@ -109,7 +109,7 @@ class MNISTDataModule(VisionDataModule):
         return mnist_transforms
 
     @staticmethod
-    def add_dataset_specific_args(parent_parser) -> ArgumentParser:
+    def add_dataset_specific_args(parent_parser: ArgumentParser) -> ArgumentParser:
         parser = ArgumentParser(parents=[parent_parser], add_help=False)
 
         parser.add_argument("--data_dir", type=str, default=".")

--- a/pl_bolts/datamodules/stl10_datamodule.py
+++ b/pl_bolts/datamodules/stl10_datamodule.py
@@ -307,7 +307,7 @@ class STL10DataModule(LightningDataModule):  # pragma: no cover
         return data_transforms
 
     @staticmethod
-    def add_dataset_specific_args(parent_parser) -> ArgumentParser:
+    def add_dataset_specific_args(parent_parser: ArgumentParser) -> ArgumentParser:
         parser = ArgumentParser(parents=[parent_parser], add_help=False)
 
         parser.add_argument("--data_dir", type=str, default=".")

--- a/pl_bolts/datamodules/stl10_datamodule.py
+++ b/pl_bolts/datamodules/stl10_datamodule.py
@@ -1,4 +1,5 @@
 import os
+from argparse import ArgumentParser
 from typing import Any, Callable, Optional
 
 import torch
@@ -304,3 +305,13 @@ class STL10DataModule(LightningDataModule):  # pragma: no cover
     def _default_transforms(self) -> Callable:
         data_transforms = transform_lib.Compose([transform_lib.ToTensor(), stl10_normalization()])
         return data_transforms
+
+    @staticmethod
+    def add_dataset_specific_args(parent_parser) -> ArgumentParser:
+        parser = ArgumentParser(parents=[parent_parser], add_help=False)
+
+        parser.add_argument("--data_dir", type=str, default=".")
+        parser.add_argument("--num_workers", type=int, default=0)
+        parser.add_argument("--batch_size", type=int, default=32)
+
+        return parser


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Discussed in #874 

Add a static method `add_dataset_specific_args` that adds `data_dir`, `num_workers`, and `batch_size` to CLI parser for `CIFAR10DataModule`, `ImageNetDataModule`, `MNISTDataModule`, and `STL10DataModule`

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does **only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes?
- N/A Did you write any **new necessary tests**? \[not needed for typos/docs\]
- [x] Did you verify new and **existing tests** pass locally with your changes?
- N/A If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review

- [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
