### PR TITLE
Add otaj to the CI/CD codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,10 +15,10 @@
 /setup.py             @borda @ethanwharris
 
 # CI/CD
-/.github/workflows/   @borda @ethanwharris @akihironitta
-/.github/*.yml        @borda @ethanwharris @akihironitta
-/.azure/              @borda @ethanwharris @akihironitta
-/*.yml                @borda @ethanwharris @akihironitta
+/.github/workflows/   @borda @ethanwharris @otaj @akihironitta
+/.github/*.yml        @borda @ethanwharris @otaj @akihironitta
+/.azure/              @borda @ethanwharris @otaj @akihironitta
+/*.yml                @borda @ethanwharris @otaj @akihironitta
 
 # Docs
 /docs/                          @edenlightning @borda


### PR DESCRIPTION
## What does this PR do?
Adding @otaj since otaj is already one of the CI/CD codeowners in the lightning repo.

## Before submitting

- [👀] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does **only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes?
- [n/a] Did you write any **new necessary tests**? \[not needed for typos/docs\]
- [n/a] Did you verify new and **existing tests** pass locally with your changes?
- [n/a] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

## PR review

- [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
