### PR TITLE
Fix broken doc formatting by adding missing blank line

### DIFF
--- a/pl_bolts/models/self_supervised/moco/moco2_module.py
+++ b/pl_bolts/models/self_supervised/moco/moco2_module.py
@@ -47,6 +47,7 @@ class Moco_v2(LightningModule):
         - `William Falcon <https://github.com/williamFalcon>`_
 
     Example::
+
         from pl_bolts.models.self_supervised import Moco_v2
         model = Moco_v2()
         trainer = Trainer()


### PR DESCRIPTION
## What does this PR do?

This PR fixes currently broken (see screenshot below) formatting of the "Examples" section of `pl_bolts.models.self_supervised.Moco_v2`'s docstring.

![image](https://user-images.githubusercontent.com/13014700/199947562-ce526881-707b-46c6-b203-a97593ce0752.png)


## Before submitting

- ~[ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)~
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does **only one thing**, instead of bundling different changes together?
- ~[ ] Did you make sure to **update the documentation** with your changes?~
- ~[ ] Did you write any **new necessary tests**? \[not needed for typos/docs\]~
- [ ] Did you verify new and **existing tests** pass locally with your changes?
- ~[ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?~

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review

- [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

