### PR TITLE
Replace LightningLogger by Logger

### DIFF
--- a/pl_bolts/callbacks/data_monitor.py
+++ b/pl_bolts/callbacks/data_monitor.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 import numpy as np
 import torch
 from pytorch_lightning import Callback, LightningModule, Trainer
-from pytorch_lightning.loggers import LightningLoggerBase, TensorBoardLogger, WandbLogger
+from pytorch_lightning.loggers import Logger, TensorBoardLogger, WandbLogger
 from pytorch_lightning.utilities import rank_zero_warn
 from pytorch_lightning.utilities.apply_func import apply_to_collection
 from torch import Tensor, nn
@@ -97,7 +97,7 @@ class DataMonitorBase(Callback):
 
             logger.experiment.log(data={name: wandb.Histogram(tensor)}, commit=False)
 
-    def _is_logger_available(self, logger: LightningLoggerBase) -> bool:
+    def _is_logger_available(self, logger: Logger) -> bool:
         available = True
         if not logger:
             rank_zero_warn("Cannot log histograms because Trainer has no logger.")

--- a/requirements/models.txt
+++ b/requirements/models.txt
@@ -1,8 +1,8 @@
-torchvision>=0.10.*
+torchvision>=0.10
 scikit-learn>=1.0.2
 Pillow
 opencv-python-headless
-gym[atari]>=0.17.2, <0.20.0  # needed for RL
-atari_py==0.2.*
-box2d-py==2.3.*
+gym[atari]>=0.17.2, <0.20.0
+atari_py>=0.2, <0.3
+box2d-py>=2.3, <2.4
 opencv-python>=4.5.5.62


### PR DESCRIPTION
LightningLoggerBase is deprecated in the latest release of pl

## What does this PR do?

LightningLoggerBase is deprecated in the latest release of pl.
Replace LightningLogger by Logger

Fixes # (issue)

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-bolts/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure your PR does **only one thing**, instead of bundling different changes together?
- [X] Did you make sure to **update the documentation** with your changes?
- [X] Did you write any **new necessary tests**? \[not needed for typos/docs\]
- [X] Did you verify new and **existing tests** pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-bolts/blob/master/CHANGELOG.md)?

## PR review

- [X] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
