### PR TITLE
renamed LightningLoggerBase to Logger

### DIFF
--- a/pl_bolts/callbacks/data_monitor.py
+++ b/pl_bolts/callbacks/data_monitor.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 import numpy as np
 import torch
 from pytorch_lightning import Callback, LightningModule, Trainer
-from pytorch_lightning.loggers import LightningLoggerBase, TensorBoardLogger, WandbLogger
+from pytorch_lightning.loggers import Logger, TensorBoardLogger, WandbLogger
 from pytorch_lightning.utilities import rank_zero_warn
 from pytorch_lightning.utilities.apply_func import apply_to_collection
 from torch import Tensor, nn
@@ -97,7 +97,7 @@ class DataMonitorBase(Callback):
 
             logger.experiment.log(data={name: wandb.Histogram(tensor)}, commit=False)
 
-    def _is_logger_available(self, logger: LightningLoggerBase) -> bool:
+    def _is_logger_available(self, logger: Logger) -> bool:
         available = True
         if not logger:
             rank_zero_warn("Cannot log histograms because Trainer has no logger.")


### PR DESCRIPTION
fixes https://github.com/Lightning-AI/lightning-bolts/issues/983

Relevant issue in pytorch-lightning:

https://github.com/Lightning-AI/lightning/issues/11971

## What does this PR do?

Renames LightningLoggerBase to Logger since this has been changed in PyTorch lightning package 1 year ago.

Fixes # (issue)
https://github.com/Lightning-AI/lightning-bolts/issues/983
